### PR TITLE
Added support for .docx files using MS Office viewer and for .doc using Monaco Editor

### DIFF
--- a/src/components/blocks/Groups/fileviewer.jsx
+++ b/src/components/blocks/Groups/fileviewer.jsx
@@ -13,6 +13,7 @@ import Layout from "../../ui/Layout";
 import { toast } from "react-toastify";
 import dynamic from "next/dynamic";
 import PdfViewer from "../../ui/PdfViewer";
+import { IFrame } from "@/src/components/ui/DocxViewer";
 
 const Editor = dynamic(() => import("@monaco-editor/react"), {
   ssr: false,
@@ -129,8 +130,7 @@ const FileViewerBlock = ({ url, fileType, doc, groupId: group_id }) => {
           <source src={url} type={`video/${fileType}`} />
         </video>
       ),
-      docx: <p>Some docx file</p>,
-      txt: <p>{fileContent} </p>,
+      docx: <IFrame url={url} />,
       code: (
         <CustomEditor
           fileContent={fileContent}
@@ -138,7 +138,6 @@ const FileViewerBlock = ({ url, fileType, doc, groupId: group_id }) => {
           path={`group_${group_id}/${doc.name}`}
           fetchFile={fetchFile}
         />
-        // <p>{`${fileContent.publicUrl}`}</p>
       ),
     };
 

--- a/src/components/ui/DocxViewer/index.jsx
+++ b/src/components/ui/DocxViewer/index.jsx
@@ -1,0 +1,5 @@
+export const IFrame = ({ url }) => {
+    return (
+        <iframe src={`https://view.officeapps.live.com/op/embed.aspx?src=${url}`} width="100%" height="100%" frameBorder="0">This is an embedded <a target="_blank" href="https://office.com">Microsoft Office</a> document, powered by <a target="_blank" href="https://office.com/webapps">Office</a>.</iframe>
+    );
+}

--- a/src/constants/extensions.js
+++ b/src/constants/extensions.js
@@ -1,22 +1,31 @@
-export const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg', 'webp'];
-export const VIDEO_EXTENSIONS = ['mp4', 'avi', 'mov', 'wmv'];
-export const TEXT_EXTENSIONS = ['txt', 'doc', 'docx', 'pdf'];
-export const PROGRAMMING_EXTENSIONS = [,
+export const IMAGE_EXTENSIONS = [
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "bmp",
+  "svg",
+  "webp",
+];
+export const VIDEO_EXTENSIONS = ["mp4", "avi", "mov", "wmv"];
+export const TEXT_EXTENSIONS = ["pdf"];
+export const PROGRAMMING_EXTENSIONS = [
+  "doc",
   "txt",
-    "java",
-    "py",
-    "cpp",
-    "c",
-    "h",
-    "cs",
-    "js",
-    "html",
-    "css",
-    "scss",
-    "json",
-    "xml",
-    "yaml",
-    "md",
-    "sh",
-    "sql",
-  ];
+  "java",
+  "py",
+  "cpp",
+  "c",
+  "h",
+  "cs",
+  "js",
+  "html",
+  "css",
+  "scss",
+  "json",
+  "xml",
+  "yaml",
+  "md",
+  "sh",
+  "sql",
+];


### PR DESCRIPTION
This pull request implements functionality to support viewing .**docx** files through the **MS Office** viewer and .doc files using the Monaco Editor. Users can now seamlessly preview both file formats within our application, enhancing usability and versatility. This enhancement expands our file format compatibility, empowering users to work with a broader range of document types efficiently. The implementation adheres to best practices and ensures a smooth user experience while interacting with .docx and .doc files.